### PR TITLE
Update tile.js: adding 'numberOfLines' prop

### DIFF
--- a/src/tile/Tile.js
+++ b/src/tile/Tile.js
@@ -31,6 +31,7 @@ const Tile = props => {
     imageContainerStyle,
     containerStyle,
     contentContainerStyle,
+    titleNumberOfLines,
     ...attributes
   } = props;
 
@@ -120,7 +121,7 @@ const Tile = props => {
           contentContainerStyle && contentContainerStyle,
         ]}
       >
-        <Text h4 style={[styles.text, titleStyle && titleStyle]}>
+        <Text h4 style={[styles.text, titleStyle && titleStyle]} numberOfLines={titleNumberOfLines>
           {title}
         </Text>
         {children}


### PR DESCRIPTION
Adding 'numberOfLines' prop for Text component(displaying title) in tile.js.
So users can set numberOfLines for their 'title' text.